### PR TITLE
Handle Single Quotes Properly

### DIFF
--- a/src/mkdocs_spellcheck/words.py
+++ b/src/mkdocs_spellcheck/words.py
@@ -42,7 +42,7 @@ def _strip_tags(html, ignore_code):
     return stripper.get_data()
 
 
-not_letters_nor_spaces = re.compile(r"[^\w\s-]")
+not_letters_nor_spaces = re.compile(r"[^\w\s-]|(?:\B\'|\'\B|\B\'\B)")
 dashes_or_spaces = re.compile(r"[-\s]+")
 
 

--- a/src/mkdocs_spellcheck/words.py
+++ b/src/mkdocs_spellcheck/words.py
@@ -42,7 +42,7 @@ def _strip_tags(html, ignore_code):
     return stripper.get_data()
 
 
-not_letters_nor_spaces = re.compile(r"[^\w\s-]|(?:\B\'|\'\B|\B\'\B)")
+not_letters_nor_spaces = re.compile(r"(?:(\B\'|\'\B|\B\'\B)|[^\w\s\'-])")
 dashes_or_spaces = re.compile(r"[-\s]+")
 
 

--- a/src/mkdocs_spellcheck/words.py
+++ b/src/mkdocs_spellcheck/words.py
@@ -42,7 +42,7 @@ def _strip_tags(html, ignore_code):
     return stripper.get_data()
 
 
-not_letters_nor_spaces = re.compile(r"(?:(\B\'|\'\B|\B\'\B)|[^\w\s\'-])")
+not_letters_nor_spaces = re.compile(r"(?:(\B\'|\'\B|\B\'\B|\'s)|[^\w\s\'-])")
 dashes_or_spaces = re.compile(r"[-\s]+")
 
 


### PR DESCRIPTION
## Overview

The current word separation in `mkdocs-spellcheck` causes words like `isn't`, `wouldn't` etc to be split such that they are checked as `isn` and `wouldn`, leading to erroneous warnings about misspelling. 

This PR modifies the regex for separating out words. Previously this regex would only check letters and spaces, now it also removes: 
- "Non-word boundaries" (`\B`) preceding, following or surrounding a word (this means that single quotes can be used to surround a word without being retained for spellchecking) 
- Possessive noun endings (`'s`), this means that the word preceding the `'s` will be checked against the dictionary

## Steps to Test

Tested with:
- Mkdocs v1.5.2
- mkdocs-spellcheck v1.0.0

Steps:
- Create a new mkdocs installation with `mkdocs new mydocs`
- Setup `mkdocs.yml` in the new directory to look as follows:
    ```yaml
    site_name: My Docs
    plugins:
    - spellcheck:
        backends:
          - symspellpy
          - codespell
    ```
- Set `docs/index.md` to contain the following
    ```markdown
    This isn't normally matched, I've 'quoted' something that shouldn't be used for spellcheck.

    This Pull Request increases the plugin's power!

    isn
    ```
- In my local instance, I hacked the regex changes into the plugin file to quickly test it
- Run `mkdocs serve -s` and only an error for `isn` should be returned (Note: I've left in these deprecation warnings as these may be something else that needs fixing) 
    ```txt
    $ mkdocs serve -s
    INFO    -  DeprecationWarning: warning_filter doesn't do anything since MkDocs 1.2 and will be removed soon. All messages on the `mkdocs` logger
               get counted automatically.
                 File "/opt/homebrew/lib/python3.11/site-packages/mkdocs_spellcheck/loggers.py", line 8, in <module>
                   from mkdocs.utils import warning_filter
                 File "/opt/homebrew/lib/python3.11/site-packages/mkdocs/utils/__init__.py", line 453, in __getattr__
                   warnings.warn(
    INFO    -  Building documentation...
    INFO    -  DeprecationWarning: path is deprecated. Use files() instead. Refer to
               https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
                 File "/opt/homebrew/lib/python3.11/site-packages/mkdocs_spellcheck/backends/symspellpy.py", line 31, in __init__
                   with resources.path("symspellpy", "frequency_dictionary_en_82_765.txt") as dictionary_path:
             File
               "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/importlib/resources/_legacy.py",
               line 18, in wrapper
                   warnings.warn(
    INFO    -  Cleaning site directory
    WARNING -  mkdocs_spellcheck: (symspellpy) index.md: Misspelled 'isn', did you mean 'in', 'is', 'inn', 'sin', 'ian', 'ion', 'ign', 'isl', 'ism'?

    Aborted with 1 warnings in strict mode!
    ```
