### PR TITLE
Prevent loading of unused backends

### DIFF
--- a/src/mkdocs_spellcheck/plugin.py
+++ b/src/mkdocs_spellcheck/plugin.py
@@ -99,9 +99,7 @@ class SpellCheckPlugin(BasePlugin):
 
         known_words = self.config["known_words"]
         if isinstance(known_words, str):
-            self.known_words |= set(
-                Path(config["docs_dir"], known_words).read_text().splitlines()
-            )
+            self.known_words |= set(Path(config["docs_dir"], known_words).read_text().splitlines())
         else:
             self.known_words |= set(known_words)
 

--- a/src/mkdocs_spellcheck/plugin.py
+++ b/src/mkdocs_spellcheck/plugin.py
@@ -13,19 +13,37 @@ from mkdocs.config import Config
 from mkdocs.config.config_options import Type as MkType
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure.pages import Page
-from symspellpy import SymSpell
 
-from mkdocs_spellcheck.backends import codespell, symspellpy
+from mkdocs_spellcheck.backends import Backend
 from mkdocs_spellcheck.loggers import get_logger
 from mkdocs_spellcheck.words import get_words
 
 logger = get_logger(__name__)
 
 
-backends_map: dict[str, Any] = {
-    "symspellpy": symspellpy.SymspellpyBackend,
-    "codespell": codespell.CodespellBackend,
-}
+def load_backend(name: str) -> Backend:
+    """Load the specified backend.
+
+    This function imports the specified backend and returns its class.
+    It is important not to import the backends at the top level, as
+    they may not be installed.
+
+    Arguments:
+        name: The name of the backend to load.
+
+    Returns:
+        The backend class.
+    """
+    if name == "symspellpy":
+        from mkdocs_spellcheck.backends import symspellpy
+
+        return symspellpy.SymspellpyBackend
+    elif name == "codespell":
+        from mkdocs_spellcheck.backends import codespell
+
+        return codespell.CodespellBackend
+    else:
+        raise ValueError(f"Unknown backend: {name}")
 
 
 class SpellCheckPlugin(BasePlugin):
@@ -53,7 +71,6 @@ class SpellCheckPlugin(BasePlugin):
 
     def __init__(self) -> None:  # noqa: D107
         self.known_words: set[str] = set()
-        self.spell: SymSpell = None
         super().__init__()
 
     def on_config(self, config: Config, **kwargs: Any) -> Config:
@@ -82,7 +99,9 @@ class SpellCheckPlugin(BasePlugin):
 
         known_words = self.config["known_words"]
         if isinstance(known_words, str):
-            self.known_words |= set(Path(config["docs_dir"], known_words).read_text().splitlines())
+            self.known_words |= set(
+                Path(config["docs_dir"], known_words).read_text().splitlines()
+            )
         else:
             self.known_words |= set(known_words)
 
@@ -93,7 +112,7 @@ class SpellCheckPlugin(BasePlugin):
                 backend_config = {}
             else:
                 backend_name, backend_config = next(iter(backend_conf.items()))
-            self.backends[backend_name] = backends_map[backend_name](
+            self.backends[backend_name] = load_backend(backend_name)(
                 known_words=self.known_words,
                 config=backend_config,
             )


### PR DESCRIPTION
This change changes how the backends are imported, instead of importing all of them every backend is
loaded lazy only when its needed.

This solves the problem that dependencies from unused backends need to be installed even if the are not
used (e.g. symspellpy depends on editdistpy which
needs to be build from source on Windows requiring a compiler ...).