### PR TITLE
feat: Add config option to ignore files based on Unix shell-style wildcard pattern matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # python
 *.egg-info/
 *.py[cod]
+pdm.lock
 .venv/
 .venvs/
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 # python
 *.egg-info/
 *.py[cod]
-pdm.lock
 .venv/
 .venvs/
 /build/

--- a/README.md
+++ b/README.md
@@ -54,13 +54,10 @@ plugins:
     # keep unicode characters
     allow_unicode: no
 
-    # skip files entirely
+    # skip files entirely (supports Unix shell-style wildcards)
     skip_files:
     - credits.md
     - coverage.md
-
-    # skip files matching Unix shell-style wildcards
-    skip_file_globs:
     - reference/* 
 
     # whether to only check in strict mode

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ plugins:
     - credits.md
     - coverage.md
 
+    # skip files matching Unix shell-style wildcards
+    skip_file_globs:
+    - reference/* 
+
     # whether to only check in strict mode
     strict_only: yes
 ```

--- a/docs/known_words.txt
+++ b/docs/known_words.txt
@@ -30,3 +30,6 @@ ahrens
 dev
 fr
 uv
+codespell
+mkdocs_spellcheck
+symspellpy

--- a/src/mkdocs_spellcheck/plugin.py
+++ b/src/mkdocs_spellcheck/plugin.py
@@ -67,7 +67,6 @@ class SpellCheckPlugin(BasePlugin):
         ("backends", MkType(list, default=["symspellpy"])),
         ("known_words", MkType((str, list), default=[])),
         ("skip_files", MkType(list, default=[])),
-        ("skip_file_globs", MkType(list, default=[])),
         ("min_length", MkType(int, default=2)),
         ("max_capital", MkType(int, default=1)),
         ("ignore_code", MkType(bool, default=True)),
@@ -92,7 +91,6 @@ class SpellCheckPlugin(BasePlugin):
         self.strict_only = self.config["strict_only"]
         self.backends_config = self.config["backends"]
         self.skip_files = self.config["skip_files"]
-        self.skip_file_globs = self.config["skip_file_globs"]
         self.min_length = self.config["min_length"]
         self.max_capital = self.config["max_capital"]
         self.ignore_code = self.config["ignore_code"]
@@ -132,10 +130,7 @@ class SpellCheckPlugin(BasePlugin):
             page: The page instance.
             **kwargs: Additional arguments passed by MkDocs.
         """
-        if self.run and not (
-            page.file.src_path in self.skip_files
-            or any(fnmatch.fnmatch(page.file.src_path, pattern) for pattern in self.skip_file_globs)
-        ):
+        if self.run and not any(fnmatch.fnmatch(page.file.src_path, pattern) for pattern in self.skip_files):
             words = get_words(
                 html,
                 known_words=self.known_words,

--- a/src/mkdocs_spellcheck/plugin.py
+++ b/src/mkdocs_spellcheck/plugin.py
@@ -5,6 +5,7 @@ A spell checker plugin for MkDocs.
 
 from __future__ import annotations
 
+import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -66,6 +67,7 @@ class SpellCheckPlugin(BasePlugin):
         ("backends", MkType(list, default=["symspellpy"])),
         ("known_words", MkType((str, list), default=[])),
         ("skip_files", MkType(list, default=[])),
+        ("skip_file_globs", MkType(list, default=[])),
         ("min_length", MkType(int, default=2)),
         ("max_capital", MkType(int, default=1)),
         ("ignore_code", MkType(bool, default=True)),
@@ -89,7 +91,10 @@ class SpellCheckPlugin(BasePlugin):
         """
         self.strict_only = self.config["strict_only"]
         self.backends_config = self.config["backends"]
-        self.skip_files = self.config["skip_files"]
+        # Convert the skip files into a set of Path objects to make it
+        # OS-agnostic and increase lookup efficiency
+        self.skip_files = {Path(x) for x in self.config["skip_files"]}
+        self.skip_file_globs = self.config["skip_file_globs"]
         self.min_length = self.config["min_length"]
         self.max_capital = self.config["max_capital"]
         self.ignore_code = self.config["ignore_code"]
@@ -129,7 +134,10 @@ class SpellCheckPlugin(BasePlugin):
             page: The page instance.
             **kwargs: Additional arguments passed by MkDocs.
         """
-        if self.run and page.file.src_path not in self.skip_files:
+        if self.run and not (
+            Path(page.file.src_path) in self.skip_files
+            or any(fnmatch.fnmatch(page.file.src_path, pattern) for pattern in self.skip_file_globs)
+        ):
             words = get_words(
                 html,
                 known_words=self.known_words,

--- a/src/mkdocs_spellcheck/plugin.py
+++ b/src/mkdocs_spellcheck/plugin.py
@@ -91,9 +91,7 @@ class SpellCheckPlugin(BasePlugin):
         """
         self.strict_only = self.config["strict_only"]
         self.backends_config = self.config["backends"]
-        # Convert the skip files into a set of Path objects to make it
-        # OS-agnostic and increase lookup efficiency
-        self.skip_files = {Path(x) for x in self.config["skip_files"]}
+        self.skip_files = self.config["skip_files"]
         self.skip_file_globs = self.config["skip_file_globs"]
         self.min_length = self.config["min_length"]
         self.max_capital = self.config["max_capital"]
@@ -135,7 +133,7 @@ class SpellCheckPlugin(BasePlugin):
             **kwargs: Additional arguments passed by MkDocs.
         """
         if self.run and not (
-            Path(page.file.src_path) in self.skip_files
+            page.file.src_path in self.skip_files
             or any(fnmatch.fnmatch(page.file.src_path, pattern) for pattern in self.skip_file_globs)
         ):
             words = get_words(


### PR DESCRIPTION
This adds the `skip_file_globs` config option to enable skipping files based on a Unix shell-style glob. This also updates the `skip_files` config option to treat file paths as OS-agnostic.

fixes #21 
resolves: #20