### PR TITLE
Ignore contents of <script> tag in spellcheck

### DIFF
--- a/src/mkdocs_spellcheck/_internal/words.py
+++ b/src/mkdocs_spellcheck/_internal/words.py
@@ -21,16 +21,21 @@ class _MLStripper(HTMLParser):
         self.text = StringIO()
         self.ignore_code = ignore_code
         self.in_code_tag = False
+        self.in_script_tag = False
         self.in_guard = False
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: ARG002
         if tag == "code":
             self.in_code_tag = True
+        if tag == "script":
+            self.in_script_tag = True
         self.text.write(" ")
 
     def handle_endtag(self, tag: str) -> None:
         if tag == "code":
             self.in_code_tag = False
+        if tag == "script":
+            self.in_script_tag = False
 
     def handle_comment(self, data: str) -> None:
         data = data.strip()
@@ -43,6 +48,9 @@ class _MLStripper(HTMLParser):
 
     def handle_data(self, data: str) -> None:
         if self.ignore_code and self.in_code_tag:
+            return
+
+        if self.in_script_tag:
             return
 
         if self.in_guard:


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

We're using `mkdocs-jupyter` to render Jupyter notebooks in our documentation, which uses `nbconvert`. The latest update of `nbconvert` from 7.16.6 to 7.17.0 triggered an issue with `mkdocs-spellcheck`:
```
WARNING -  mkdocs_spellcheck: (codespell) test.ipynb: Misspelled 'curren', did you mean 'current'?
WARNING -  mkdocs_spellcheck: (codespell) test.ipynb: Misspelled 'notin', did you mean 'noting, not in, notion'?
```

This is because the latest nbconvert release [includes](https://github.com/jupyter/nbconvert/pull/2224) a list of HTML entities in a `<script>` tag.

With this PR, the spellcheck will skip over the `<script>` contents.

### Relevant resources
<!-- Link to any relevant GitHub issue, PR or discussion, section in online docs, etc. -->

- https://github.com/danielfrg/mkdocs-jupyter
- https://github.com/jupyter/nbconvert/releases/tag/v7.17.0
